### PR TITLE
Add class to hold common string test data

### DIFF
--- a/net/adoptopenjdk/bumblebench/string/StringTestData.java
+++ b/net/adoptopenjdk/bumblebench/string/StringTestData.java
@@ -1,0 +1,6 @@
+public class StringTestData {
+    static final char[] POSSIBLE_CHARS = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+            'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E',
+            'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+            'Y', 'Z', ' ', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+}


### PR DESCRIPTION
StringTestData will be used to hold data common to multiple
String benchmarks, currently it will contain a list
of possible characters used in common strings, this includes
alphanumerics and spaces.

Signed-off-by: Daniel Hong <daniel.hong@live.com>