### PR TITLE
Add arrayCopy BumbleBench

### DIFF
--- a/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyByte.java
+++ b/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyByte.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.arraycopy;
+
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+/**
+ * 
+ * 
+ * This benchmark simply tests the speed of copying byte arrays in either backward
+ * or forward direction. This direction can be specified by options.
+ * 
+ * The reported score is in terms of number of array copies done in one second.
+ * Length of array is fixed to 8192 but type can be changed using options.
+ * 
+ * Also this benchmark in all iterations copies 4000 elements which can be changed
+ * through options.
+ * 
+ * */
+
+
+public final class ArrayCopyByte extends MicroBench {
+	private static final boolean BACKWARD_ARRAYCOPY = option("backwardArrayCopy", false);
+	private static final int ARRAY_LENGTH = option("arrayLength", 8192);
+	private static final int COPY_ELEMENTS = option("copyElements", 4000);
+	private static final int MAX_ITERATIONS_PER_LOOP = option("maxIterations", 10000000);
+
+	private static byte[] byteArray = new byte[ARRAY_LENGTH];
+	private static int dstPoint;
+	private static int srcPoint;
+	
+	static {
+		for (int i=0; i < ARRAY_LENGTH; i++) {
+			byteArray[i] = (byte)i;
+		}
+
+		if (BACKWARD_ARRAYCOPY) {
+			srcPoint = 0;
+			dstPoint = 10;
+		}
+		else {
+			srcPoint=10;
+			dstPoint=0;
+		}
+	}
+
+	protected int maxIterationsPerLoop() {
+		return MAX_ITERATIONS_PER_LOOP;
+	}
+
+	@Override
+	protected long doBatch(long numIterations) throws InterruptedException {
+		for (long loop = 0; loop < numIterations; loop++) {
+			System.arraycopy(byteArray, srcPoint, byteArray, dstPoint, COPY_ELEMENTS);
+		}
+		return numIterations;
+	}
+}

--- a/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyChar.java
+++ b/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyChar.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.arraycopy;
+
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+/**
+ * 
+ * 
+ * This benchmark simply tests the speed of copying char arrays in either backward
+ * or forward direction. This direction can be specified by options.
+ * 
+ * The reported score is in terms of number of array copies done in one second.
+ * Length of array is fixed to 8192 but type can be changed using options.
+ * 
+ * Also this benchmark in all iterations copies 4000 elements which can be changed
+ * through options.
+ * 
+ * */
+
+
+public final class ArrayCopyChar extends MicroBench {
+	private static final boolean BACKWARD_ARRAYCOPY = option("backwardArrayCopy", false);
+	private static final int ARRAY_LENGTH = option("arrayLength", 8192);
+	private static final int COPY_ELEMENTS = option("copyElements", 4000);
+	private static final int MAX_ITERATIONS_PER_LOOP = option("maxIterations", 10000000);
+
+	private static char[] charArray = new char[ARRAY_LENGTH];
+	private static int dstPoint;
+	private static int srcPoint;
+	
+	static {
+		for (int i=0; i < ARRAY_LENGTH; i++) {
+			charArray[i] = (char)i;
+		}
+
+		if (BACKWARD_ARRAYCOPY) {
+			srcPoint = 0;
+			dstPoint = 10;
+		}
+		else {
+			srcPoint=10;
+			dstPoint=0;
+		}
+	}
+
+	protected int maxIterationsPerLoop() {
+		return MAX_ITERATIONS_PER_LOOP;
+	}
+
+	@Override
+	protected long doBatch(long numIterations) throws InterruptedException {
+		for (long loop = 0; loop < numIterations; loop++) {
+			System.arraycopy(charArray, srcPoint, charArray, dstPoint, COPY_ELEMENTS);
+		}
+		return numIterations;
+	}
+}

--- a/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyInt.java
+++ b/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyInt.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.arraycopy;
+
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+/**
+ * 
+ * 
+ * This benchmark simply tests the speed of copying integer arrays in either backward
+ * or forward direction. This direction can be specified by options.
+ * 
+ * The reported score is in terms of number of array copies done in one second.
+ * Length of array is fixed to 8192 but type can be changed using options.
+ * 
+ * Also this benchmark in all iterations copies 4000 elements which can be changed
+ * through options.
+ * 
+ * */
+
+
+public final class ArrayCopyInt extends MicroBench {
+	private static final boolean BACKWARD_ARRAYCOPY = option("backwardArrayCopy", false);
+	private static final int ARRAY_LENGTH = option("arrayLength", 8192);
+	private static final int COPY_ELEMENTS = option("copyElements", 4000);
+	private static final int MAX_ITERATIONS_PER_LOOP = option("maxIterations", 10000000);
+
+	private static int[] intArray = new int[ARRAY_LENGTH];
+	private static int dstPoint;
+	private static int srcPoint;
+	
+	static {
+		for (int i=0; i < ARRAY_LENGTH; i++) {
+			intArray[i] = i;
+		}
+
+		if (BACKWARD_ARRAYCOPY) {
+			srcPoint = 0;
+			dstPoint = 10;
+		}
+		else {
+			srcPoint=10;
+			dstPoint=0;
+		}
+	}
+
+	protected int maxIterationsPerLoop() {
+		return MAX_ITERATIONS_PER_LOOP;
+	}
+
+	@Override
+	protected long doBatch(long numIterations) throws InterruptedException {
+		for (long loop = 0; loop < numIterations; loop++) {
+			System.arraycopy(intArray, srcPoint, intArray, dstPoint, COPY_ELEMENTS);
+		}
+		return numIterations;
+	}
+}

--- a/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyLong.java
+++ b/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyLong.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.arraycopy;
+
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+/**
+ * 
+ * 
+ * This benchmark simply tests the speed of copying Long arrays in either backward
+ * or forward direction. This direction can be specified by options.
+ * 
+ * The reported score is in terms of number of array copies done in one second.
+ * Length of array is fixed to 8192 but type can be changed using options.
+ * 
+ * Also this benchmark in all iterations copies 4000 elements which can be changed
+ * through options.
+ * 
+ * */
+
+
+public final class ArrayCopyLong extends MicroBench {
+	private static final boolean BACKWARD_ARRAYCOPY = option("backwardArrayCopy", false);
+	private static final int ARRAY_LENGTH = option("arrayLength", 8192);
+	private static final int COPY_ELEMENTS = option("copyElements", 4000);
+	private static final int MAX_ITERATIONS_PER_LOOP = option("maxIterations", 10000000);
+
+	private static long[] longArray = new long[ARRAY_LENGTH];
+	private static int dstPoint;
+	private static int srcPoint;
+	
+	static {
+		for (int i=0; i < ARRAY_LENGTH; i++) {
+			longArray[i] = (long)i;
+		}
+
+		if (BACKWARD_ARRAYCOPY) {
+			srcPoint = 0;
+			dstPoint = 10;
+		}
+		else {
+			srcPoint=10;
+			dstPoint=0;
+		}
+	}
+
+	protected int maxIterationsPerLoop() {
+		return MAX_ITERATIONS_PER_LOOP;
+	}
+
+	@Override
+	protected long doBatch(long numIterations) throws InterruptedException {
+		for (long loop = 0; loop < numIterations; loop++) {
+			System.arraycopy(longArray, srcPoint, longArray, dstPoint, COPY_ELEMENTS);
+		}
+		return numIterations;
+	}
+}

--- a/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyObject.java
+++ b/net/adoptopenjdk/bumblebench/arraycopy/ArrayCopyObject.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.arraycopy;
+
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+/**
+ * 
+ * 
+ * This benchmark simply tests the speed of copying char arrays in either backward
+ * or forward direction. This direction can be specified by options.
+ * 
+ * The reported score is in terms of number of array copies done in one second.
+ * Length of array is fixed to 8192 but type can be changed using options.
+ * 
+ * Also this benchmark in all iterations copies 4000 elements which can be changed
+ * through options.
+ * 
+ * */
+
+
+public final class ArrayCopyObject extends MicroBench {
+	private static final boolean BACKWARD_ARRAYCOPY = option("backwardArrayCopy", false);
+	private static final int ARRAY_LENGTH = option("arrayLength", 8192);
+	private static final int COPY_ELEMENTS = option("copyElements", 4000);
+	private static final int MAX_ITERATIONS_PER_LOOP = option("maxIterations", 10000000);
+
+	private static String[] objArray = new String[ARRAY_LENGTH];
+	private static int dstPoint;
+	private static int srcPoint;
+	
+	static {
+		for (int i=0; i < ARRAY_LENGTH; i++) {
+			objArray[i] = Integer.toString(i);
+		}
+
+		if (BACKWARD_ARRAYCOPY) {
+			srcPoint = 0;
+			dstPoint = 10;
+		}
+		else {
+			srcPoint=10;
+			dstPoint=0;
+		}
+	}
+
+	protected int maxIterationsPerLoop() {
+		return MAX_ITERATIONS_PER_LOOP;
+	}
+
+	@Override
+	protected long doBatch(long numIterations) throws InterruptedException {
+		for (long loop = 0; loop < numIterations; loop++) {
+			System.arraycopy(objArray, srcPoint, objArray, dstPoint, COPY_ELEMENTS);
+		}
+		return numIterations;
+	}
+}


### PR DESCRIPTION
Add benchmark to test array copy speed in forward or backward direction.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>