### PR TITLE
Removed javax.xml.bind.DatatypeConverter import

### DIFF
--- a/net/adoptopenjdk/bumblebench/crypto/DigestBench.java
+++ b/net/adoptopenjdk/bumblebench/crypto/DigestBench.java
@@ -20,8 +20,6 @@ import java.security.NoSuchProviderException;
 import java.util.Arrays;
 import java.util.Random;
 
-import javax.xml.bind.DatatypeConverter;
-
 import net.adoptopenjdk.bumblebench.core.MicroBench;
 
 public final class DigestBench extends MicroBench {

--- a/net/adoptopenjdk/bumblebench/crypto/HMACBench.java
+++ b/net/adoptopenjdk/bumblebench/crypto/HMACBench.java
@@ -23,8 +23,6 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidKeyException;
 
-import javax.xml.bind.DatatypeConverter;
-
 import net.adoptopenjdk.bumblebench.core.MicroBench;
 
 public final class HMACBench extends MicroBench {


### PR DESCRIPTION
Removing the library does not break the compilation (so it is not used)
javax.xml.bind is moved to java.xml.bind and is now deprecated in new Java

Signed-off-by: samasri <samasri@ibm.com>