### PR TITLE
Changed µ to u in BumbleBench.java

### DIFF
--- a/net/adoptopenjdk/bumblebench/core/BumbleBench.java
+++ b/net/adoptopenjdk/bumblebench/core/BumbleBench.java
@@ -450,7 +450,7 @@ public abstract class BumbleBench extends Util implements Runnable {
 			if (exponential.endsWith("E-9"))
 				sb.replace(eIndex, sb.length(), "n");
 			else if (exponential.endsWith("E-6"))
-				sb.replace(eIndex, sb.length(), "μ");
+				sb.replace(eIndex, sb.length(), "u");
 			else if (exponential.endsWith("E-3"))
 				sb.replace(eIndex, sb.length(), "m");
 			else if (exponential.endsWith("E+3"))


### PR DESCRIPTION
Compiling with µ gives unmappable character for encoding ASCII error
Issue not happening on all systems
Issue spotted on a docker image downloaded from openj9 with jdk11

Signed-off-by: samasri <samasri@ibm.com>