### PR TITLE
Add encoding option to "string" test to prevent build failure

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -119,6 +119,7 @@ execute a build.
         <javac srcdir="${src-string}" 
             debug="on" 
             destdir=""
+            encoding="UTF-8"
             source="1.8"
             target="1.8" 
             includeantruntime="false"


### PR DESCRIPTION
Since the StringIndexOfStringBench test contains some UTF-8 chars. Force to use `UTF-8` encoding to prevent build failure if the default encoding is not `UTF-8`. 