### PR TITLE
Lock Contention Benchmark

### DIFF
--- a/net/adoptopenjdk/bumblebench/examples/LockContention.java
+++ b/net/adoptopenjdk/bumblebench/examples/LockContention.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.examples;
+
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+public final class LockContention extends MicroBench {
+	static final boolean BUSY_WAIT = Boolean.parseBoolean(System.getProperty("LockContention.BUSY_WAIT"));
+
+	static final Synch synch = new Synch();
+
+	static Boolean init = false;
+
+	protected long doBatch(long numIterations) throws InterruptedException {
+		if (!init) {
+			synchronized(init) {
+				if (!init) {
+					System.out.println("[INPUT] BUSY_WAIT: " + BUSY_WAIT);
+					System.out.println("[INPUT] WORK_INTERVAL: " + Synch.INTERVAL);
+					System.out.println("[INPUT] NUM_THREADS: " + System.getProperty("BumbleBench.parallelInstances"));
+					init = true;
+				}
+			}
+		}
+		
+		for (long i = 0; i < numIterations; i++) {
+			if (BUSY_WAIT) {
+				synch.doWorkBusyWait(i);
+			} else {
+				synch.doWorkThreadSleep(i);
+			}
+		}
+
+		return numIterations;
+	}
+}

--- a/net/adoptopenjdk/bumblebench/examples/Synch.java
+++ b/net/adoptopenjdk/bumblebench/examples/Synch.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.examples;
+
+public class Synch {
+	static final int INTERVAL = Integer.parseInt(System.getProperty("Synch.WORK_INTERVAL"));
+
+	private long count;
+
+	public Synch() {
+		if ((INTERVAL < 0) && (INTERVAL > 999999)) {
+			throw new IllegalArgumentException("SYNCH.WORK_INTERVAL should be between 0-999999");
+		}
+		count = 0;
+	}
+
+	public void doWorkBusyWait(long value) {
+		synchronized (this) {
+			this.count += value;
+			
+			/* Busy wait. This can cause CPU thrashing. */
+			long start = System.nanoTime();
+			long end = 0;
+			do {
+				end = System.nanoTime();
+			} while(start + INTERVAL >= end);
+		}
+	}
+
+	public void doWorkThreadSleep(long value) throws InterruptedException {
+		synchronized (this) {
+			this.count += value;
+			
+			/* Thread.sleep has an overhead. Use busy wait to avoid this overhead. */
+			Thread.sleep(0, INTERVAL);
+		}
+	}
+
+	public long getCount() {
+		return count;
+	}
+}


### PR DESCRIPTION
**Properties (control parameters):**
1. `-DLockContention.BUSY_WAIT=[true|false]`
	-- true:  invokes Synch.doWorkBusyWait. CPU thrashing.
	-- false: invokes Synch.doWorkThreadSleep. Thread.sleep overhead.
	-- Parameter to specify the type of critical section.

2. `-DSynch.WORK_INTERVAL=[0-999999]`
    -- Specifies time interval to busy wait or Thread.sleep in nano-seconds.
    -- Parameter to control the size of the critical section.

3. `-DBumbleBench.parallelInstances=<N>`
	-- Number of threads.
	-- Parameter to control the amount of lock contention.

**Build:**
```
    ant dist
```

**Run:**
```
    java -DLockContention.BUSY_WAIT=true -DSynch.WORK_INTERVAL=100 \
    -DBumbleBench.parallelInstances=5 -jar BumbleBench.jar LockContention
```

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>