### PR TITLE
Fix FormatFlagsConversionMismatchException

### DIFF
--- a/net/adoptopenjdk/bumblebench/core/BumbleBench.java
+++ b/net/adoptopenjdk/bumblebench/core/BumbleBench.java
@@ -263,10 +263,16 @@ public abstract class BumbleBench extends Util implements Runnable {
 			out().println("   -- interrupted: " + e.getMessage() + " --");
 		}
 
-		String spaces = String.format("%" + (_name.length()-5) + "s", "");
 		if (verify()) {
-			out().println("\n  " + _name + " score: " + String.format("%f",_maxPeak) + " (" + score(_maxPeak) + " " + logPoints(_maxPeak) + "%)");
-		out().println("  " + spaces + "uncertainty: " + percentage(_uncertainty) + "%");
+			String score_prefix = "  " + _name + " score: ";
+			String uncertainty_prefix = "  uncertainty: ";
+			if (score_prefix.length() < uncertainty_prefix.length()) {
+				score_prefix = " ".repeat(uncertainty_prefix.length() - score_prefix.length()) + score_prefix;
+			} else if (score_prefix.length() > uncertainty_prefix.length()) {
+				uncertainty_prefix = " ".repeat(score_prefix.length() - uncertainty_prefix.length()) + uncertainty_prefix;
+			}
+			out().println("\n" + score_prefix + String.format("%f",_maxPeak) + " (" + score(_maxPeak) + " " + logPoints(_maxPeak) + "%)");
+			out().println(uncertainty_prefix + percentage(_uncertainty) + "%");
 		} else {
 			out().println("ERROR: failed verification.");
 		}


### PR DESCRIPTION
The string formatting code which constructs and prints the lines reporting the score and uncertainty at the end of a benchmark run can be found in [BumbleBench.run()](https://github.com/adoptium/bumblebench/blob/master/net/adoptopenjdk/bumblebench/core/BumbleBench.java#L266-L272). In order to ensure an aesthetic alignment of the two lines, a number of spaces are sometimes added to the beginning of the second line, as in this example:

```
  TrigBench score: 24703088.000000 (24.70M 1702.2%)
      uncertainty:   1.9%
```

However, the line of code which produces the correct number of spaces assumes that the name of the benchmark is at least 6 characters:

```java
String spaces = String.format("%" + (_name.length()-5) + "s", "");
```

Since `%0s` is not a valid string format specifier, if the class name is 5 characters long, we get a crash. Although obviously less significant, if the class name is 4 characters or less, we don't get a crash, but we also don't get the alignment that this code intends to produce. For example, here is the output for a benchmark with a 4 character name, `Test`:

```
  Test score: 7955413.000000 (7.955M 1588.9%)
   uncertainty:   1.1%
```

This PR improves upon that string formatting code to remove any dependency on the length of the benchmark name to ensure alignment of the score and uncertainty lines and fix the runtime exception.