### PR TITLE
Add benchmarks for Unsafe put and get methods

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,8 +10,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-This is a build.xml which executes the main openjdk.build build.xml 
-to allow tools which invoke a root level build.xml file to 
+This is a build.xml which executes the main openjdk.build build.xml
+to allow tools which invoke a root level build.xml file to
 execute a build.
 -->
 
@@ -35,11 +35,13 @@ execute a build.
  	<property name="src-string" value="${basedir}/net/adoptopenjdk/bumblebench/string"/>
 	<property name="src-jni" value="${basedir}/net/adoptopenjdk/bumblebench/jni"/>
 	<property name="src-arraycopy" value="${basedir}/net/adoptopenjdk/bumblebench/arraycopy"/>
+    <property name="src-unsafe" value="${basedir}/net/adoptopenjdk/bumblebench/unsafe"/>
+    <property environment="env"/>
 
 	<target name="compile-all" description="compile" >
 
 		<!-- core -->
-		<javac srcdir="${src-core}" 
+		<javac srcdir="${src-core}"
              destdir=""
              debug="on"
              source="1.8"
@@ -47,7 +49,7 @@ execute a build.
              includeantruntime="false"
              excludes="">
 		</javac>
-		<javac srcdir="${src-core}" 
+		<javac srcdir="${src-core}"
              destdir=""
              debug="on"
              source="1.8"
@@ -57,100 +59,100 @@ execute a build.
 		</javac>
 
 		<!-- collections -->
-		<javac srcdir="${src-collections}" 
-            debug="on" 
+		<javac srcdir="${src-collections}"
+            debug="on"
             destdir=""
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-core}"
         	excludes="**/*ambda*.java">
 		</javac>
 
-		<javac srcdir="${src-collections}" 
-            debug="on" 
+		<javac srcdir="${src-collections}"
+            debug="on"
             destdir=""
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-core}"
             includes="**/*ambda*.java">
 		</javac>
 
 		<!-- crypto -->
-		<javac srcdir="${src-crypto}" 
-            debug="on" 
+		<javac srcdir="${src-crypto}"
+            debug="on"
             destdir=""
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-core}">
 		</javac>
 
 		<!-- examples -->
-		<javac srcdir="${src-examples}" 
-            debug="on" 
+		<javac srcdir="${src-examples}"
+            debug="on"
             destdir=""
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-examples}"
             includes="**/SocketEchoBench.java">
 		</javac>
-		<javac srcdir="${src-examples}" 
-             debug="on" 
+		<javac srcdir="${src-examples}"
+             debug="on"
              destdir=""
              source="1.8"
-             target="1.8" 
+             target="1.8"
              includeantruntime="false"
              classpath="${src-examples}"
              includes="**/*ambda*.java">
 		</javac>
-		<javac srcdir="${src-examples}" 
-            debug="on" 
+		<javac srcdir="${src-examples}"
+            debug="on"
             destdir=""
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-examples}"
         	excludes="**/*ambda*.java, **/SocketEchoBench.java">
 		</javac>
 
 		<!-- string -->
-        <javac srcdir="${src-string}" 
-            debug="on" 
+        <javac srcdir="${src-string}"
+            debug="on"
             destdir=""
             encoding="UTF-8"
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-string}">
         </javac>
-		
+
 		<!-- gpu -->
-		<javac srcdir="${src-gpu}" 
-            debug="on" 
+		<javac srcdir="${src-gpu}"
+            debug="on"
             destdir=""
             source="1.8"
-            target="1.8" 
+            target="1.8"
             includeantruntime="false"
             classpath="${src-gpu}">
 		</javac>
 
 		<!-- indy -->
 		<!--
-        <javac srcdir="${src-indy}" 
-             debug="on" 
+        <javac srcdir="${src-indy}"
+             debug="on"
              destdir=""
              source="1.8"
-             target="1.8" 
+             target="1.8"
              classpath="${src-indy},${basedir}/asm-all-4.0.jar">
          </javac>
     	-->
 
 		<!-- lambda -->
-		<javac srcdir="${src-lambda}" 
-             debug="on" 
+		<javac srcdir="${src-lambda}"
+             debug="on"
              destdir=""
              source="1.8"
              target="1.8"
@@ -158,8 +160,8 @@ execute a build.
 		</javac>
 
 		<!-- JNI -->
-		<javac srcdir="${src-jni}" 
-             debug="on" 
+		<javac srcdir="${src-jni}"
+             debug="on"
              destdir=""
              source="1.8"
              target="1.8"
@@ -167,32 +169,43 @@ execute a build.
 		</javac>
 
 		<!-- math -->
-		<javac srcdir="${src-math}" 
-             debug="on" 
+		<javac srcdir="${src-math}"
+             debug="on"
              destdir=""
              source="1.8"
-             target="1.8" 
+             target="1.8"
 			 includeantruntime="false"
              classpath="${src-math}">
 		</javac>
 
 		<!-- humble -->
-		<javac srcdir="${src-humble}" 
+		<javac srcdir="${src-humble}"
         debug="on"
         destdir=""
         source="1.8"
-        target="1.8" 
+        target="1.8"
         includeantruntime="false">
 		</javac>
 
 		<!-- arraycopy -->
-		<javac srcdir="${src-arraycopy}" 
+		<javac srcdir="${src-arraycopy}"
         debug="on"
         destdir=""
         source="1.8"
-        target="1.8" 
+        target="1.8"
         includeantruntime="false">
 		</javac>
+
+        <!-- unsafe -->
+        <javac srcdir="${src-unsafe}"
+            debug="on"
+            destdir=""
+            source="21"
+            target="21"
+            includeantruntime="false"
+            excludes="generator/**">
+            <compilerarg line="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED"/>
+        </javac>
 	</target>
 
 	<!-- Create BumbleBench.jar and clean up -->
@@ -201,7 +214,7 @@ execute a build.
 			<arg value="-c" />
 			<arg value="rm -f BumbleBench.jar" />
 		</exec>
-		
+
 		<jar jarfile="${dist}/BumbleBench.jar" filesonly="true">
 			<fileset dir="${basedir}"
              	excludes="**/asm-all-4.0.jar,**/Makefile,**/*.mk, **/build.xml. **/.project">

--- a/net/adoptopenjdk/bumblebench/core/Launcher.java
+++ b/net/adoptopenjdk/bumblebench/core/Launcher.java
@@ -78,6 +78,7 @@ public class Launcher extends Util {
 		+ ":net.adoptopenjdk.bumblebench.string"
 		+ ":net.adoptopenjdk.bumblebench.humble"
 		+ ":net.adoptopenjdk.bumblebench.arraycopy"
+		+ ":net.adoptopenjdk.bumblebench.unsafe"
 		;
 
 	public static Class loadTestClass(String[] packageNames, String name) throws ClassNotFoundException, IOException {

--- a/net/adoptopenjdk/bumblebench/unsafe/Base.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/Base.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Runtime;
+import java.lang.Thread;
+
+public class Base {
+    public static final Unsafe UNSAFE;
+    public static volatile int dump;
+    public static volatile int incrementBy = 0;
+
+    static {
+        try {
+            UNSAFE = Unsafe.getUnsafe();
+        } catch (IllegalAccessError e) {
+            System.err.println("add \"--add-exports java.base/jdk.internal.misc=ALL-UNNAMED\" to your java command");
+            throw new RuntimeException("Unable to get Unsafe instance.", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to get Unsafe instance.", e);
+        }
+    }
+
+    public static abstract class Offsets {}
+
+    public static class AbsoluteOffsets extends Offsets {
+        public Object base;
+        public long field1Offset, field2Offset, field3Offset, field4Offset, field5Offset;
+
+        public AbsoluteOffsets(Object b, long f1, long f2, long f3, long f4, long f5) {
+            base = b;
+            field1Offset = f1;
+            field2Offset = f2;
+            field3Offset = f3;
+            field4Offset = f4;
+            field5Offset = f5;
+        }
+    }
+
+    public static class RelativeOffsets extends AbsoluteOffsets {
+        public long baseOffset;
+
+        public RelativeOffsets(Object b, long bo, long f1, long f2, long f3, long f4, long f5) {
+            super(b, f1, f2, f3, f4, f5);
+            baseOffset = bo;
+        }
+    }
+
+    public static class Objects extends Offsets {
+        public Object base1, base2, base3, base4, base5;
+        public long offset;
+
+        public Objects(Object b1, Object b2, Object b3, Object b4, Object b5, long o) {
+            base1 = b1;
+            base2 = b2;
+            base3 = b3;
+            base4 = b4;
+            base5 = b5;
+            offset = o;
+        }
+    }
+
+    public static interface BenchmarkProvider<T extends Offsets> {
+        public T getNativeOffsets();
+        public T getStaticOffsets();
+        public T getObjectOffsets();
+        public T getArrayOffsets();
+
+        public long stressGet(long numIterations, T offsets);
+        public long stressGetOpaque(long numIterations, T offsets);
+        public long stressGetAcquire(long numIterations, T offsets);
+        public long stressGetVolatile(long numIterations, T offsets);
+
+        public long stressPut(long numIterations, T offsets);
+        public long stressPutOpaque(long numIterations, T offsets);
+        public long stressPutRelease(long numIterations, T offsets);
+        public long stressPutVolatile(long numIterations, T offsets);
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/BooleanProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/BooleanProvider.java
@@ -1,0 +1,285 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class BooleanProvider implements Base.BenchmarkProvider<Base.AbsoluteOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile int dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.AbsoluteOffsets nativeOffsets;
+    static {
+        // Assume that one boolean fits in one byte
+        long offset1 = UNSAFE.allocateMemory(5);
+        long offset2 = offset1 + 1;
+        long offset3 = offset1 + 2;
+        long offset4 = offset1 + 3;
+        long offset5 = offset1 + 4;
+
+        UNSAFE.putBoolean(null, offset1, true);
+        UNSAFE.putBoolean(null, offset2, false);
+        UNSAFE.putBoolean(null, offset3, true);
+        UNSAFE.putBoolean(null, offset4, false);
+        UNSAFE.putBoolean(null, offset5, true);
+
+        nativeOffsets = new Base.AbsoluteOffsets(null, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.AbsoluteOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static boolean field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            staticOffsets = new Base.AbsoluteOffsets(
+                UNSAFE.staticFieldBase(f1),
+                UNSAFE.staticFieldOffset(f1),
+                UNSAFE.staticFieldOffset(f2),
+                UNSAFE.staticFieldOffset(f3),
+                UNSAFE.staticFieldOffset(f4),
+                UNSAFE.staticFieldOffset(f5)
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.AbsoluteOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public boolean field1, field2, field3, field4, field5;
+        }
+
+        objectOffsets = new Base.AbsoluteOffsets(
+            new ObjectMember(),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field1"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field2"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field3"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field4"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field5")
+        );
+    }
+
+    public Base.AbsoluteOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets arrayOffsets;
+    static {
+        int offset = UNSAFE.arrayBaseOffset(boolean[].class);
+        int ascale = UNSAFE.arrayIndexScale(boolean[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        arrayOffsets = new Base.AbsoluteOffsets(
+            new boolean[5],
+            offset,
+            offset + (1 << shift),
+            offset + (2 << shift),
+            offset + (3 << shift),
+            offset + (4 << shift)
+        );
+    }
+
+    public Base.AbsoluteOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getBoolean(base, o1) ? 1 : 0;
+            acc2 += UNSAFE.getBoolean(base, o2) ? 1 : 0;
+            acc3 += UNSAFE.getBoolean(base, o3) ? 1 : 0;
+            acc4 += UNSAFE.getBoolean(base, o4) ? 1 : 0;
+            acc5 += UNSAFE.getBoolean(base, o5) ? 1 : 0;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getBooleanOpaque(base, o1) ? 1 : 0;
+            acc2 += UNSAFE.getBooleanOpaque(base, o2) ? 1 : 0;
+            acc3 += UNSAFE.getBooleanOpaque(base, o3) ? 1 : 0;
+            acc4 += UNSAFE.getBooleanOpaque(base, o4) ? 1 : 0;
+            acc5 += UNSAFE.getBooleanOpaque(base, o5) ? 1 : 0;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getBooleanAcquire(base, o1) ? 1 : 0;
+            acc2 += UNSAFE.getBooleanAcquire(base, o2) ? 1 : 0;
+            acc3 += UNSAFE.getBooleanAcquire(base, o3) ? 1 : 0;
+            acc4 += UNSAFE.getBooleanAcquire(base, o4) ? 1 : 0;
+            acc5 += UNSAFE.getBooleanAcquire(base, o5) ? 1 : 0;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getBooleanVolatile(base, o1) ? 1 : 0;
+            acc2 += UNSAFE.getBooleanVolatile(base, o2) ? 1 : 0;
+            acc3 += UNSAFE.getBooleanVolatile(base, o3) ? 1 : 0;
+            acc4 += UNSAFE.getBooleanVolatile(base, o4) ? 1 : 0;
+            acc5 += UNSAFE.getBooleanVolatile(base, o5) ? 1 : 0;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putBoolean(base, o1, (i & 1) == 0); o1 += inc;
+            UNSAFE.putBoolean(base, o2, (i & 1) == 0); o2 += inc;
+            UNSAFE.putBoolean(base, o3, (i & 1) == 0); o3 += inc;
+            UNSAFE.putBoolean(base, o4, (i & 1) == 0); o4 += inc;
+            UNSAFE.putBoolean(base, o5, (i & 1) == 0); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putBooleanOpaque(base, o1, (i & 1) == 0); o1 += inc;
+            UNSAFE.putBooleanOpaque(base, o2, (i & 1) == 0); o2 += inc;
+            UNSAFE.putBooleanOpaque(base, o3, (i & 1) == 0); o3 += inc;
+            UNSAFE.putBooleanOpaque(base, o4, (i & 1) == 0); o4 += inc;
+            UNSAFE.putBooleanOpaque(base, o5, (i & 1) == 0); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putBooleanRelease(base, o1, (i & 1) == 0); o1 += inc;
+            UNSAFE.putBooleanRelease(base, o2, (i & 1) == 0); o2 += inc;
+            UNSAFE.putBooleanRelease(base, o3, (i & 1) == 0); o3 += inc;
+            UNSAFE.putBooleanRelease(base, o4, (i & 1) == 0); o4 += inc;
+            UNSAFE.putBooleanRelease(base, o5, (i & 1) == 0); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putBooleanVolatile(base, o1, (i & 1) == 0); o1 += inc;
+            UNSAFE.putBooleanVolatile(base, o2, (i & 1) == 0); o2 += inc;
+            UNSAFE.putBooleanVolatile(base, o3, (i & 1) == 0); o3 += inc;
+            UNSAFE.putBooleanVolatile(base, o4, (i & 1) == 0); o4 += inc;
+            UNSAFE.putBooleanVolatile(base, o5, (i & 1) == 0); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/ByteProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/ByteProvider.java
@@ -1,0 +1,308 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Byte;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class ByteProvider implements Base.BenchmarkProvider<Base.RelativeOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile int dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.RelativeOffsets nativeOffsets;
+    static {
+        long baseOffset = UNSAFE.allocateMemory(5 * Byte.BYTES);
+        byte offset1 = (byte) 0;
+        byte offset2 = (byte) Byte.BYTES;
+        byte offset3 = (byte) 2 * Byte.BYTES;
+        byte offset4 = (byte) 3 * Byte.BYTES;
+        byte offset5 = (byte) 4 * Byte.BYTES;
+
+        UNSAFE.putByte(null, baseOffset + offset1, offset2);
+        UNSAFE.putByte(null, baseOffset + offset2, offset3);
+        UNSAFE.putByte(null, baseOffset + offset3, offset4);
+        UNSAFE.putByte(null, baseOffset + offset4, offset5);
+        UNSAFE.putByte(null, baseOffset + offset5, offset1);
+
+        nativeOffsets = new Base.RelativeOffsets(null, baseOffset, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.RelativeOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.RelativeOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static byte field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            long baseOffset = UNSAFE.staticFieldOffset(f1);
+            byte field1Offset = 0;
+            byte field2Offset = (byte) (UNSAFE.staticFieldOffset(f2) - baseOffset);
+            byte field3Offset = (byte) (UNSAFE.staticFieldOffset(f3) - baseOffset);
+            byte field4Offset = (byte) (UNSAFE.staticFieldOffset(f4) - baseOffset);
+            byte field5Offset = (byte) (UNSAFE.staticFieldOffset(f5) - baseOffset);
+
+            StaticField.field1 = field2Offset;
+            StaticField.field2 = field3Offset;
+            StaticField.field3 = field4Offset;
+            StaticField.field4 = field5Offset;
+            StaticField.field5 = field1Offset;
+
+            staticOffsets = new Base.RelativeOffsets(
+                UNSAFE.staticFieldBase(f1),
+                baseOffset,
+                field1Offset,
+                field2Offset,
+                field3Offset,
+                field4Offset,
+                field5Offset
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.RelativeOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.RelativeOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public byte field1, field2, field3, field4, field5;
+
+            public ObjectMember(byte f1, byte f2, byte f3, byte f4, byte f5) {
+                field1 = f1;
+                field2 = f2;
+                field3 = f3;
+                field4 = f4;
+                field5 = f5;
+            }
+        }
+
+        long baseOffset = UNSAFE.objectFieldOffset(ObjectMember.class, "field1");
+        byte field1Offset = 0;
+        byte field2Offset = (byte) (UNSAFE.objectFieldOffset(ObjectMember.class, "field2") - baseOffset);
+        byte field3Offset = (byte) (UNSAFE.objectFieldOffset(ObjectMember.class, "field3") - baseOffset);
+        byte field4Offset = (byte) (UNSAFE.objectFieldOffset(ObjectMember.class, "field4") - baseOffset);
+        byte field5Offset = (byte) (UNSAFE.objectFieldOffset(ObjectMember.class, "field5") - baseOffset);
+
+        objectOffsets = new Base.RelativeOffsets(
+            new ObjectMember(field2Offset, field3Offset, field4Offset, field5Offset, field1Offset),
+            baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset
+        );
+    }
+
+    public Base.RelativeOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.RelativeOffsets arrayOffsets;
+    static {
+        int baseOffset = UNSAFE.arrayBaseOffset(byte[].class);
+        int ascale = UNSAFE.arrayIndexScale(byte[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        byte field1Offset = 0;
+        byte field2Offset = (byte) (1 << shift);
+        byte field3Offset = (byte) (2 << shift);
+        byte field4Offset = (byte) (3 << shift);
+        byte field5Offset = (byte) (4 << shift);
+
+        byte[] arr = {field2Offset, field3Offset, field4Offset, field5Offset, field1Offset};
+
+        arrayOffsets = new Base.RelativeOffsets(arr, baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset);
+    }
+
+    public Base.RelativeOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        byte o1 = (byte) offsets.field1Offset;
+        byte o2 = (byte) offsets.field2Offset;
+        byte o3 = (byte) offsets.field3Offset;
+        byte o4 = (byte) offsets.field4Offset;
+        byte o5 = (byte) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getByte(base, baseOffset + o1);
+            o2 = UNSAFE.getByte(base, baseOffset + o2);
+            o3 = UNSAFE.getByte(base, baseOffset + o3);
+            o4 = UNSAFE.getByte(base, baseOffset + o4);
+            o5 = UNSAFE.getByte(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        byte o1 = (byte) offsets.field1Offset;
+        byte o2 = (byte) offsets.field2Offset;
+        byte o3 = (byte) offsets.field3Offset;
+        byte o4 = (byte) offsets.field4Offset;
+        byte o5 = (byte) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getByteOpaque(base, baseOffset + o1);
+            o2 = UNSAFE.getByteOpaque(base, baseOffset + o2);
+            o3 = UNSAFE.getByteOpaque(base, baseOffset + o3);
+            o4 = UNSAFE.getByteOpaque(base, baseOffset + o4);
+            o5 = UNSAFE.getByteOpaque(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        byte o1 = (byte) offsets.field1Offset;
+        byte o2 = (byte) offsets.field2Offset;
+        byte o3 = (byte) offsets.field3Offset;
+        byte o4 = (byte) offsets.field4Offset;
+        byte o5 = (byte) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getByteAcquire(base, baseOffset + o1);
+            o2 = UNSAFE.getByteAcquire(base, baseOffset + o2);
+            o3 = UNSAFE.getByteAcquire(base, baseOffset + o3);
+            o4 = UNSAFE.getByteAcquire(base, baseOffset + o4);
+            o5 = UNSAFE.getByteAcquire(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        byte o1 = (byte) offsets.field1Offset;
+        byte o2 = (byte) offsets.field2Offset;
+        byte o3 = (byte) offsets.field3Offset;
+        byte o4 = (byte) offsets.field4Offset;
+        byte o5 = (byte) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getByteVolatile(base, baseOffset + o1);
+            o2 = UNSAFE.getByteVolatile(base, baseOffset + o2);
+            o3 = UNSAFE.getByteVolatile(base, baseOffset + o3);
+            o4 = UNSAFE.getByteVolatile(base, baseOffset + o4);
+            o5 = UNSAFE.getByteVolatile(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+                UNSAFE.putByte(base, o1, (byte) i); o1 += inc;
+                UNSAFE.putByte(base, o2, (byte) i); o2 += inc;
+                UNSAFE.putByte(base, o3, (byte) i); o3 += inc;
+                UNSAFE.putByte(base, o4, (byte) i); o4 += inc;
+                UNSAFE.putByte(base, o5, (byte) i); o5 += inc;
+            }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+                UNSAFE.putByteOpaque(base, o1, (byte) i); o1 += inc;
+                UNSAFE.putByteOpaque(base, o2, (byte) i); o2 += inc;
+                UNSAFE.putByteOpaque(base, o3, (byte) i); o3 += inc;
+                UNSAFE.putByteOpaque(base, o4, (byte) i); o4 += inc;
+                UNSAFE.putByteOpaque(base, o5, (byte) i); o5 += inc;
+            }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+                UNSAFE.putByteRelease(base, o1, (byte) i); o1 += inc;
+                UNSAFE.putByteRelease(base, o2, (byte) i); o2 += inc;
+                UNSAFE.putByteRelease(base, o3, (byte) i); o3 += inc;
+                UNSAFE.putByteRelease(base, o4, (byte) i); o4 += inc;
+                UNSAFE.putByteRelease(base, o5, (byte) i); o5 += inc;
+            }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+                UNSAFE.putByteVolatile(base, o1, (byte) i); o1 += inc;
+                UNSAFE.putByteVolatile(base, o2, (byte) i); o2 += inc;
+                UNSAFE.putByteVolatile(base, o3, (byte) i); o3 += inc;
+                UNSAFE.putByteVolatile(base, o4, (byte) i); o4 += inc;
+                UNSAFE.putByteVolatile(base, o5, (byte) i); o5 += inc;
+            }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/CharProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/CharProvider.java
@@ -1,0 +1,308 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Character;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class CharProvider implements Base.BenchmarkProvider<Base.RelativeOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile int dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.RelativeOffsets nativeOffsets;
+    static {
+        long baseOffset = UNSAFE.allocateMemory(5 * Character.BYTES);
+        char offset1 = (char) 0;
+        char offset2 = (char) Character.BYTES;
+        char offset3 = (char) 2 * Character.BYTES;
+        char offset4 = (char) 3 * Character.BYTES;
+        char offset5 = (char) 4 * Character.BYTES;
+
+        UNSAFE.putChar(null, baseOffset + offset1, offset2);
+        UNSAFE.putChar(null, baseOffset + offset2, offset3);
+        UNSAFE.putChar(null, baseOffset + offset3, offset4);
+        UNSAFE.putChar(null, baseOffset + offset4, offset5);
+        UNSAFE.putChar(null, baseOffset + offset5, offset1);
+
+        nativeOffsets = new Base.RelativeOffsets(null, baseOffset, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.RelativeOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.RelativeOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static char field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            long baseOffset = UNSAFE.staticFieldOffset(f1);
+            char field1Offset = 0;
+            char field2Offset = (char) (UNSAFE.staticFieldOffset(f2) - baseOffset);
+            char field3Offset = (char) (UNSAFE.staticFieldOffset(f3) - baseOffset);
+            char field4Offset = (char) (UNSAFE.staticFieldOffset(f4) - baseOffset);
+            char field5Offset = (char) (UNSAFE.staticFieldOffset(f5) - baseOffset);
+
+            StaticField.field1 = field2Offset;
+            StaticField.field2 = field3Offset;
+            StaticField.field3 = field4Offset;
+            StaticField.field4 = field5Offset;
+            StaticField.field5 = field1Offset;
+
+            staticOffsets = new Base.RelativeOffsets(
+                UNSAFE.staticFieldBase(f1),
+                baseOffset,
+                field1Offset,
+                field2Offset,
+                field3Offset,
+                field4Offset,
+                field5Offset
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.RelativeOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.RelativeOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public char field1, field2, field3, field4, field5;
+
+            public ObjectMember(char f1, char f2, char f3, char f4, char f5) {
+                field1 = f1;
+                field2 = f2;
+                field3 = f3;
+                field4 = f4;
+                field5 = f5;
+            }
+        }
+
+        long baseOffset = UNSAFE.objectFieldOffset(ObjectMember.class, "field1");
+        char field1Offset = 0;
+        char field2Offset = (char) (UNSAFE.objectFieldOffset(ObjectMember.class, "field2") - baseOffset);
+        char field3Offset = (char) (UNSAFE.objectFieldOffset(ObjectMember.class, "field3") - baseOffset);
+        char field4Offset = (char) (UNSAFE.objectFieldOffset(ObjectMember.class, "field4") - baseOffset);
+        char field5Offset = (char) (UNSAFE.objectFieldOffset(ObjectMember.class, "field5") - baseOffset);
+
+        objectOffsets = new Base.RelativeOffsets(
+            new ObjectMember(field2Offset, field3Offset, field4Offset, field5Offset, field1Offset),
+            baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset
+        );
+    }
+
+    public Base.RelativeOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.RelativeOffsets arrayOffsets;
+    static {
+        int baseOffset = UNSAFE.arrayBaseOffset(char[].class);
+        int ascale = UNSAFE.arrayIndexScale(char[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        char field1Offset = 0;
+        char field2Offset = (char) (1 << shift);
+        char field3Offset = (char) (2 << shift);
+        char field4Offset = (char) (3 << shift);
+        char field5Offset = (char) (4 << shift);
+
+        char[] arr = {field2Offset, field3Offset, field4Offset, field5Offset, field1Offset};
+
+        arrayOffsets = new Base.RelativeOffsets(arr, baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset);
+    }
+
+    public Base.RelativeOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        char o1 = (char) offsets.field1Offset;
+        char o2 = (char) offsets.field2Offset;
+        char o3 = (char) offsets.field3Offset;
+        char o4 = (char) offsets.field4Offset;
+        char o5 = (char) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getChar(base, baseOffset + o1);
+            o2 = UNSAFE.getChar(base, baseOffset + o2);
+            o3 = UNSAFE.getChar(base, baseOffset + o3);
+            o4 = UNSAFE.getChar(base, baseOffset + o4);
+            o5 = UNSAFE.getChar(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        char o1 = (char) offsets.field1Offset;
+        char o2 = (char) offsets.field2Offset;
+        char o3 = (char) offsets.field3Offset;
+        char o4 = (char) offsets.field4Offset;
+        char o5 = (char) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getCharOpaque(base, baseOffset + o1);
+            o2 = UNSAFE.getCharOpaque(base, baseOffset + o2);
+            o3 = UNSAFE.getCharOpaque(base, baseOffset + o3);
+            o4 = UNSAFE.getCharOpaque(base, baseOffset + o4);
+            o5 = UNSAFE.getCharOpaque(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        char o1 = (char) offsets.field1Offset;
+        char o2 = (char) offsets.field2Offset;
+        char o3 = (char) offsets.field3Offset;
+        char o4 = (char) offsets.field4Offset;
+        char o5 = (char) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getCharAcquire(base, baseOffset + o1);
+            o2 = UNSAFE.getCharAcquire(base, baseOffset + o2);
+            o3 = UNSAFE.getCharAcquire(base, baseOffset + o3);
+            o4 = UNSAFE.getCharAcquire(base, baseOffset + o4);
+            o5 = UNSAFE.getCharAcquire(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        char o1 = (char) offsets.field1Offset;
+        char o2 = (char) offsets.field2Offset;
+        char o3 = (char) offsets.field3Offset;
+        char o4 = (char) offsets.field4Offset;
+        char o5 = (char) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getCharVolatile(base, baseOffset + o1);
+            o2 = UNSAFE.getCharVolatile(base, baseOffset + o2);
+            o3 = UNSAFE.getCharVolatile(base, baseOffset + o3);
+            o4 = UNSAFE.getCharVolatile(base, baseOffset + o4);
+            o5 = UNSAFE.getCharVolatile(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putChar(base, o1, (char) i); o1 += inc;
+            UNSAFE.putChar(base, o2, (char) i); o2 += inc;
+            UNSAFE.putChar(base, o3, (char) i); o3 += inc;
+            UNSAFE.putChar(base, o4, (char) i); o4 += inc;
+            UNSAFE.putChar(base, o5, (char) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putCharOpaque(base, o1, (char) i); o1 += inc;
+            UNSAFE.putCharOpaque(base, o2, (char) i); o2 += inc;
+            UNSAFE.putCharOpaque(base, o3, (char) i); o3 += inc;
+            UNSAFE.putCharOpaque(base, o4, (char) i); o4 += inc;
+            UNSAFE.putCharOpaque(base, o5, (char) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putCharRelease(base, o1, (char) i); o1 += inc;
+            UNSAFE.putCharRelease(base, o2, (char) i); o2 += inc;
+            UNSAFE.putCharRelease(base, o3, (char) i); o3 += inc;
+            UNSAFE.putCharRelease(base, o4, (char) i); o4 += inc;
+            UNSAFE.putCharRelease(base, o5, (char) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putCharVolatile(base, o1, (char) i); o1 += inc;
+            UNSAFE.putCharVolatile(base, o2, (char) i); o2 += inc;
+            UNSAFE.putCharVolatile(base, o3, (char) i); o3 += inc;
+            UNSAFE.putCharVolatile(base, o4, (char) i); o4 += inc;
+            UNSAFE.putCharVolatile(base, o5, (char) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/DoubleProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/DoubleProvider.java
@@ -1,0 +1,291 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Double;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class DoubleProvider implements Base.BenchmarkProvider<Base.AbsoluteOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile double dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.AbsoluteOffsets nativeOffsets;
+    static {
+        long offset1 = UNSAFE.allocateMemory(5);
+        long offset2 = offset1 + Double.BYTES;
+        long offset3 = offset2 + Double.BYTES;
+        long offset4 = offset3 + Double.BYTES;
+        long offset5 = offset4 + Double.BYTES;
+
+        nativeOffsets = new Base.AbsoluteOffsets(null, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.AbsoluteOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static double field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            staticOffsets = new Base.AbsoluteOffsets(
+                UNSAFE.staticFieldBase(f1),
+                UNSAFE.staticFieldOffset(f1),
+                UNSAFE.staticFieldOffset(f2),
+                UNSAFE.staticFieldOffset(f3),
+                UNSAFE.staticFieldOffset(f4),
+                UNSAFE.staticFieldOffset(f5)
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.AbsoluteOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public double field1, field2, field3, field4, field5;
+        }
+
+        objectOffsets = new Base.AbsoluteOffsets(
+            new ObjectMember(),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field1"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field2"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field3"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field4"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field5")
+        );
+    }
+
+    public Base.AbsoluteOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets arrayOffsets;
+    static {
+        int offset = UNSAFE.arrayBaseOffset(double[].class);
+        int ascale = UNSAFE.arrayIndexScale(double[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        arrayOffsets = new Base.AbsoluteOffsets(
+            new double[5],
+            offset,
+            offset + (1 << shift),
+            offset + (2 << shift),
+            offset + (3 << shift),
+            offset + (4 << shift)
+        );
+    }
+
+    public Base.AbsoluteOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        double acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getDouble(base, o1); o1 += inc;
+            acc2 += UNSAFE.getDouble(base, o2); o2 += inc;
+            acc3 += UNSAFE.getDouble(base, o3); o3 += inc;
+            acc4 += UNSAFE.getDouble(base, o4); o4 += inc;
+            acc5 += UNSAFE.getDouble(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        double acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getDoubleOpaque(base, o1); o1 += inc;
+            acc2 += UNSAFE.getDoubleOpaque(base, o2); o2 += inc;
+            acc3 += UNSAFE.getDoubleOpaque(base, o3); o3 += inc;
+            acc4 += UNSAFE.getDoubleOpaque(base, o4); o4 += inc;
+            acc5 += UNSAFE.getDoubleOpaque(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        double acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getDoubleAcquire(base, o1); o1 += inc;
+            acc2 += UNSAFE.getDoubleAcquire(base, o2); o2 += inc;
+            acc3 += UNSAFE.getDoubleAcquire(base, o3); o3 += inc;
+            acc4 += UNSAFE.getDoubleAcquire(base, o4); o4 += inc;
+            acc5 += UNSAFE.getDoubleAcquire(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        double acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getDoubleVolatile(base, o1); o1 += inc;
+            acc2 += UNSAFE.getDoubleVolatile(base, o2); o2 += inc;
+            acc3 += UNSAFE.getDoubleVolatile(base, o3); o3 += inc;
+            acc4 += UNSAFE.getDoubleVolatile(base, o4); o4 += inc;
+            acc5 += UNSAFE.getDoubleVolatile(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        double d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putDouble(base, o1, d); o1 += inc;
+            UNSAFE.putDouble(base, o2, d); o2 += inc;
+            UNSAFE.putDouble(base, o3, d); o3 += inc;
+            UNSAFE.putDouble(base, o4, d); o4 += inc;
+            UNSAFE.putDouble(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        double d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putDoubleOpaque(base, o1, d); o1 += inc;
+            UNSAFE.putDoubleOpaque(base, o2, d); o2 += inc;
+            UNSAFE.putDoubleOpaque(base, o3, d); o3 += inc;
+            UNSAFE.putDoubleOpaque(base, o4, d); o4 += inc;
+            UNSAFE.putDoubleOpaque(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        double d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putDoubleRelease(base, o1, d); o1 += inc;
+            UNSAFE.putDoubleRelease(base, o2, d); o2 += inc;
+            UNSAFE.putDoubleRelease(base, o3, d); o3 += inc;
+            UNSAFE.putDoubleRelease(base, o4, d); o4 += inc;
+            UNSAFE.putDoubleRelease(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        double d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putDoubleVolatile(base, o1, d); o1 += inc;
+            UNSAFE.putDoubleVolatile(base, o2, d); o2 += inc;
+            UNSAFE.putDoubleVolatile(base, o3, d); o3 += inc;
+            UNSAFE.putDoubleVolatile(base, o4, d); o4 += inc;
+            UNSAFE.putDoubleVolatile(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/FloatProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/FloatProvider.java
@@ -1,0 +1,291 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Float;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class FloatProvider implements Base.BenchmarkProvider<Base.AbsoluteOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile float dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.AbsoluteOffsets nativeOffsets;
+    static {
+        long offset1 = UNSAFE.allocateMemory(5);
+        long offset2 = offset1 + Float.BYTES;
+        long offset3 = offset2 + Float.BYTES;
+        long offset4 = offset3 + Float.BYTES;
+        long offset5 = offset4 + Float.BYTES;
+
+        nativeOffsets = new Base.AbsoluteOffsets(null, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.AbsoluteOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static float field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            staticOffsets = new Base.AbsoluteOffsets(
+                UNSAFE.staticFieldBase(f1),
+                UNSAFE.staticFieldOffset(f1),
+                UNSAFE.staticFieldOffset(f2),
+                UNSAFE.staticFieldOffset(f3),
+                UNSAFE.staticFieldOffset(f4),
+                UNSAFE.staticFieldOffset(f5)
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.AbsoluteOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public float field1, field2, field3, field4, field5;
+        }
+
+        objectOffsets = new Base.AbsoluteOffsets(
+            new ObjectMember(),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field1"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field2"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field3"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field4"),
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field5")
+        );
+    }
+
+    public Base.AbsoluteOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets arrayOffsets;
+    static {
+        int offset = UNSAFE.arrayBaseOffset(float[].class);
+        int ascale = UNSAFE.arrayIndexScale(float[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        arrayOffsets = new Base.AbsoluteOffsets(
+            new float[5],
+            offset,
+            offset + (1 << shift),
+            offset + (2 << shift),
+            offset + (3 << shift),
+            offset + (4 << shift)
+        );
+    }
+
+    public Base.AbsoluteOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        float acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getFloat(base, o1); o1 += inc;
+            acc2 += UNSAFE.getFloat(base, o2); o2 += inc;
+            acc3 += UNSAFE.getFloat(base, o3); o3 += inc;
+            acc4 += UNSAFE.getFloat(base, o4); o4 += inc;
+            acc5 += UNSAFE.getFloat(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        float acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getFloatOpaque(base, o1); o1 += inc;
+            acc2 += UNSAFE.getFloatOpaque(base, o2); o2 += inc;
+            acc3 += UNSAFE.getFloatOpaque(base, o3); o3 += inc;
+            acc4 += UNSAFE.getFloatOpaque(base, o4); o4 += inc;
+            acc5 += UNSAFE.getFloatOpaque(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        float acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getFloatAcquire(base, o1); o1 += inc;
+            acc2 += UNSAFE.getFloatAcquire(base, o2); o2 += inc;
+            acc3 += UNSAFE.getFloatAcquire(base, o3); o3 += inc;
+            acc4 += UNSAFE.getFloatAcquire(base, o4); o4 += inc;
+            acc5 += UNSAFE.getFloatAcquire(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        int inc = incrementBy;
+        float acc1 = 0, acc2 = 0, acc3 = 0, acc4 = 0, acc5 = 0;
+
+        for (long i = 0; i < numIterations; i++) {
+            acc1 += UNSAFE.getFloatVolatile(base, o1); o1 += inc;
+            acc2 += UNSAFE.getFloatVolatile(base, o2); o2 += inc;
+            acc3 += UNSAFE.getFloatVolatile(base, o3); o3 += inc;
+            acc4 += UNSAFE.getFloatVolatile(base, o4); o4 += inc;
+            acc5 += UNSAFE.getFloatVolatile(base, o5); o5 += inc;
+        }
+
+        dump = acc1 + acc2 + acc3 + acc4 + acc5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        float d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putFloat(base, o1, d); o1 += inc;
+            UNSAFE.putFloat(base, o2, d); o2 += inc;
+            UNSAFE.putFloat(base, o3, d); o3 += inc;
+            UNSAFE.putFloat(base, o4, d); o4 += inc;
+            UNSAFE.putFloat(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        float d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putFloatOpaque(base, o1, d); o1 += inc;
+            UNSAFE.putFloatOpaque(base, o2, d); o2 += inc;
+            UNSAFE.putFloatOpaque(base, o3, d); o3 += inc;
+            UNSAFE.putFloatOpaque(base, o4, d); o4 += inc;
+            UNSAFE.putFloatOpaque(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        float d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putFloatRelease(base, o1, d); o1 += inc;
+            UNSAFE.putFloatRelease(base, o2, d); o2 += inc;
+            UNSAFE.putFloatRelease(base, o3, d); o3 += inc;
+            UNSAFE.putFloatRelease(base, o4, d); o4 += inc;
+            UNSAFE.putFloatRelease(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        float d = 0;
+
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++, d++) {
+            UNSAFE.putFloatVolatile(base, o1, d); o1 += inc;
+            UNSAFE.putFloatVolatile(base, o2, d); o2 += inc;
+            UNSAFE.putFloatVolatile(base, o3, d); o3 += inc;
+            UNSAFE.putFloatVolatile(base, o4, d); o4 += inc;
+            UNSAFE.putFloatVolatile(base, o5, d); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/IntProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/IntProvider.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class IntProvider implements Base.BenchmarkProvider<Base.RelativeOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile int dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.RelativeOffsets nativeOffsets;
+    static {
+        long baseOffset = UNSAFE.allocateMemory(5 * Integer.BYTES);
+        int offset1 = (int) 0;
+        int offset2 = (int) Integer.BYTES;
+        int offset3 = (int) 2 * Integer.BYTES;
+        int offset4 = (int) 3 * Integer.BYTES;
+        int offset5 = (int) 4 * Integer.BYTES;
+
+        UNSAFE.putInt(null, baseOffset + offset1, offset2);
+        UNSAFE.putInt(null, baseOffset + offset2, offset3);
+        UNSAFE.putInt(null, baseOffset + offset3, offset4);
+        UNSAFE.putInt(null, baseOffset + offset4, offset5);
+        UNSAFE.putInt(null, baseOffset + offset5, offset1);
+
+        nativeOffsets = new Base.RelativeOffsets(null, baseOffset, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.RelativeOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.RelativeOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static int field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            long baseOffset = UNSAFE.staticFieldOffset(f1);
+            int field1Offset = 0;
+            int field2Offset = (int) (UNSAFE.staticFieldOffset(f2) - baseOffset);
+            int field3Offset = (int) (UNSAFE.staticFieldOffset(f3) - baseOffset);
+            int field4Offset = (int) (UNSAFE.staticFieldOffset(f4) - baseOffset);
+            int field5Offset = (int) (UNSAFE.staticFieldOffset(f5) - baseOffset);
+
+            StaticField.field1 = field2Offset;
+            StaticField.field2 = field3Offset;
+            StaticField.field3 = field4Offset;
+            StaticField.field4 = field5Offset;
+            StaticField.field5 = field1Offset;
+
+            staticOffsets = new Base.RelativeOffsets(
+                UNSAFE.staticFieldBase(f1),
+                baseOffset,
+                field1Offset,
+                field2Offset,
+                field3Offset,
+                field4Offset,
+                field5Offset
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.RelativeOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.RelativeOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public int field1, field2, field3, field4, field5;
+
+            public ObjectMember(int f1, int f2, int f3, int f4, int f5) {
+                field1 = f1;
+                field2 = f2;
+                field3 = f3;
+                field4 = f4;
+                field5 = f5;
+            }
+        }
+
+        long baseOffset = UNSAFE.objectFieldOffset(ObjectMember.class, "field1");
+        int field1Offset = 0;
+        int field2Offset = (int) (UNSAFE.objectFieldOffset(ObjectMember.class, "field2") - baseOffset);
+        int field3Offset = (int) (UNSAFE.objectFieldOffset(ObjectMember.class, "field3") - baseOffset);
+        int field4Offset = (int) (UNSAFE.objectFieldOffset(ObjectMember.class, "field4") - baseOffset);
+        int field5Offset = (int) (UNSAFE.objectFieldOffset(ObjectMember.class, "field5") - baseOffset);
+
+        objectOffsets = new Base.RelativeOffsets(
+            new ObjectMember(field2Offset, field3Offset, field4Offset, field5Offset, field1Offset),
+            baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset
+        );
+    }
+
+    public Base.RelativeOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.RelativeOffsets arrayOffsets;
+    static {
+        int baseOffset = UNSAFE.arrayBaseOffset(int[].class);
+        int ascale = UNSAFE.arrayIndexScale(int[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        int field1Offset = 0;
+        int field2Offset = (int) (1 << shift);
+        int field3Offset = (int) (2 << shift);
+        int field4Offset = (int) (3 << shift);
+        int field5Offset = (int) (4 << shift);
+
+        int[] arr = {field2Offset, field3Offset, field4Offset, field5Offset, field1Offset};
+
+        arrayOffsets = new Base.RelativeOffsets(arr, baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset);
+    }
+
+    public Base.RelativeOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        int o1 = (int) offsets.field1Offset;
+        int o2 = (int) offsets.field2Offset;
+        int o3 = (int) offsets.field3Offset;
+        int o4 = (int) offsets.field4Offset;
+        int o5 = (int) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getInt(base, baseOffset + o1);
+            o2 = UNSAFE.getInt(base, baseOffset + o2);
+            o3 = UNSAFE.getInt(base, baseOffset + o3);
+            o4 = UNSAFE.getInt(base, baseOffset + o4);
+            o5 = UNSAFE.getInt(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        int o1 = (int) offsets.field1Offset;
+        int o2 = (int) offsets.field2Offset;
+        int o3 = (int) offsets.field3Offset;
+        int o4 = (int) offsets.field4Offset;
+        int o5 = (int) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getIntOpaque(base, baseOffset + o1);
+            o2 = UNSAFE.getIntOpaque(base, baseOffset + o2);
+            o3 = UNSAFE.getIntOpaque(base, baseOffset + o3);
+            o4 = UNSAFE.getIntOpaque(base, baseOffset + o4);
+            o5 = UNSAFE.getIntOpaque(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        int o1 = (int) offsets.field1Offset;
+        int o2 = (int) offsets.field2Offset;
+        int o3 = (int) offsets.field3Offset;
+        int o4 = (int) offsets.field4Offset;
+        int o5 = (int) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getIntAcquire(base, baseOffset + o1);
+            o2 = UNSAFE.getIntAcquire(base, baseOffset + o2);
+            o3 = UNSAFE.getIntAcquire(base, baseOffset + o3);
+            o4 = UNSAFE.getIntAcquire(base, baseOffset + o4);
+            o5 = UNSAFE.getIntAcquire(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        int o1 = (int) offsets.field1Offset;
+        int o2 = (int) offsets.field2Offset;
+        int o3 = (int) offsets.field3Offset;
+        int o4 = (int) offsets.field4Offset;
+        int o5 = (int) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getIntVolatile(base, baseOffset + o1);
+            o2 = UNSAFE.getIntVolatile(base, baseOffset + o2);
+            o3 = UNSAFE.getIntVolatile(base, baseOffset + o3);
+            o4 = UNSAFE.getIntVolatile(base, baseOffset + o4);
+            o5 = UNSAFE.getIntVolatile(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putInt(base, o1, (int) i); o1 += inc;
+            UNSAFE.putInt(base, o2, (int) i); o2 += inc;
+            UNSAFE.putInt(base, o3, (int) i); o3 += inc;
+            UNSAFE.putInt(base, o4, (int) i); o4 += inc;
+            UNSAFE.putInt(base, o5, (int) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putIntOpaque(base, o1, (int) i); o1 += inc;
+            UNSAFE.putIntOpaque(base, o2, (int) i); o2 += inc;
+            UNSAFE.putIntOpaque(base, o3, (int) i); o3 += inc;
+            UNSAFE.putIntOpaque(base, o4, (int) i); o4 += inc;
+            UNSAFE.putIntOpaque(base, o5, (int) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putIntRelease(base, o1, (int) i); o1 += inc;
+            UNSAFE.putIntRelease(base, o2, (int) i); o2 += inc;
+            UNSAFE.putIntRelease(base, o3, (int) i); o3 += inc;
+            UNSAFE.putIntRelease(base, o4, (int) i); o4 += inc;
+            UNSAFE.putIntRelease(base, o5, (int) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putIntVolatile(base, o1, (int) i); o1 += inc;
+            UNSAFE.putIntVolatile(base, o2, (int) i); o2 += inc;
+            UNSAFE.putIntVolatile(base, o3, (int) i); o3 += inc;
+            UNSAFE.putIntVolatile(base, o4, (int) i); o4 += inc;
+            UNSAFE.putIntVolatile(base, o5, (int) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/LongProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/LongProvider.java
@@ -1,0 +1,300 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Long;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class LongProvider implements Base.BenchmarkProvider<Base.AbsoluteOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile long dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.AbsoluteOffsets nativeOffsets;
+    static {
+        long offset1 = UNSAFE.allocateMemory(5 * Long.BYTES);
+        long offset2 = offset1 + Long.BYTES;
+        long offset3 = offset2 + Long.BYTES;
+        long offset4 = offset3 + Long.BYTES;
+        long offset5 = offset4 + Long.BYTES;
+
+        UNSAFE.putLong(null, offset1, offset2);
+        UNSAFE.putLong(null, offset2, offset3);
+        UNSAFE.putLong(null, offset3, offset4);
+        UNSAFE.putLong(null, offset4, offset5);
+        UNSAFE.putLong(null, offset5, offset1);
+
+        nativeOffsets = new Base.AbsoluteOffsets(null, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.AbsoluteOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static long field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            long field1Offset = UNSAFE.staticFieldOffset(f1);
+            long field2Offset = UNSAFE.staticFieldOffset(f2);
+            long field3Offset = UNSAFE.staticFieldOffset(f3);
+            long field4Offset = UNSAFE.staticFieldOffset(f4);
+            long field5Offset = UNSAFE.staticFieldOffset(f5);
+
+            StaticField.field1 = field2Offset;
+            StaticField.field2 = field3Offset;
+            StaticField.field3 = field4Offset;
+            StaticField.field4 = field5Offset;
+            StaticField.field5 = field1Offset;
+
+            staticOffsets = new Base.AbsoluteOffsets(
+                UNSAFE.staticFieldBase(f1),
+                field1Offset,
+                field2Offset,
+                field3Offset,
+                field4Offset,
+                field5Offset
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.AbsoluteOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public long field1, field2, field3, field4, field5;
+
+            public ObjectMember(long f1, long f2, long f3, long f4, long f5) {
+                field1 = f1;
+                field2 = f2;
+                field3 = f3;
+                field4 = f4;
+                field5 = f5;
+            }
+        }
+
+        long field1Offset = UNSAFE.objectFieldOffset(ObjectMember.class, "field1");
+        long field2Offset = UNSAFE.objectFieldOffset(ObjectMember.class, "field2");
+        long field3Offset = UNSAFE.objectFieldOffset(ObjectMember.class, "field3");
+        long field4Offset = UNSAFE.objectFieldOffset(ObjectMember.class, "field4");
+        long field5Offset = UNSAFE.objectFieldOffset(ObjectMember.class, "field5");
+
+        objectOffsets = new Base.AbsoluteOffsets(
+            new ObjectMember(field2Offset, field3Offset, field4Offset, field5Offset, field1Offset),
+            field1Offset, field2Offset, field3Offset, field4Offset, field5Offset
+        );
+    }
+
+    public Base.AbsoluteOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.AbsoluteOffsets arrayOffsets;
+    static {
+        int offset = UNSAFE.arrayBaseOffset(long[].class);
+        int ascale = UNSAFE.arrayIndexScale(long[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        long field1Offset = offset;
+        long field2Offset = offset + (1 << shift);
+        long field3Offset = offset + (2 << shift);
+        long field4Offset = offset + (3 << shift);
+        long field5Offset = offset + (4 << shift);
+
+        long[] arr = {field2Offset, field3Offset, field4Offset, field5Offset, field1Offset};
+
+        arrayOffsets = new Base.AbsoluteOffsets(arr, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset);
+    }
+
+    public Base.AbsoluteOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getLong(base, o1);
+            o2 = UNSAFE.getLong(base, o2);
+            o3 = UNSAFE.getLong(base, o3);
+            o4 = UNSAFE.getLong(base, o4);
+            o5 = UNSAFE.getLong(base, o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getLongOpaque(base, o1);
+            o2 = UNSAFE.getLongOpaque(base, o2);
+            o3 = UNSAFE.getLongOpaque(base, o3);
+            o4 = UNSAFE.getLongOpaque(base, o4);
+            o5 = UNSAFE.getLongOpaque(base, o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getLongAcquire(base, o1);
+            o2 = UNSAFE.getLongAcquire(base, o2);
+            o3 = UNSAFE.getLongAcquire(base, o3);
+            o4 = UNSAFE.getLongAcquire(base, o4);
+            o5 = UNSAFE.getLongAcquire(base, o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getLongAcquire(base, o1);
+            o2 = UNSAFE.getLongAcquire(base, o2);
+            o3 = UNSAFE.getLongAcquire(base, o3);
+            o4 = UNSAFE.getLongAcquire(base, o4);
+            o5 = UNSAFE.getLongAcquire(base, o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putLong(base, o1, i); o1 += inc;
+            UNSAFE.putLong(base, o2, i); o2 += inc;
+            UNSAFE.putLong(base, o3, i); o3 += inc;
+            UNSAFE.putLong(base, o4, i); o4 += inc;
+            UNSAFE.putLong(base, o5, i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putLongOpaque(base, o1, i); o1 += inc;
+            UNSAFE.putLongOpaque(base, o2, i); o2 += inc;
+            UNSAFE.putLongOpaque(base, o3, i); o3 += inc;
+            UNSAFE.putLongOpaque(base, o4, i); o4 += inc;
+            UNSAFE.putLongOpaque(base, o5, i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putLongRelease(base, o1, i); o1 += inc;
+            UNSAFE.putLongRelease(base, o2, i); o2 += inc;
+            UNSAFE.putLongRelease(base, o3, i); o3 += inc;
+            UNSAFE.putLongRelease(base, o4, i); o4 += inc;
+            UNSAFE.putLongRelease(base, o5, i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.AbsoluteOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.field1Offset;
+        long o2 = offsets.field2Offset;
+        long o3 = offsets.field3Offset;
+        long o4 = offsets.field4Offset;
+        long o5 = offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putLongVolatile(base, o1, i); o1 += inc;
+            UNSAFE.putLongVolatile(base, o2, i); o2 += inc;
+            UNSAFE.putLongVolatile(base, o3, i); o3 += inc;
+            UNSAFE.putLongVolatile(base, o4, i); o4 += inc;
+            UNSAFE.putLongVolatile(base, o5, i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/ReferenceProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/ReferenceProvider.java
@@ -1,0 +1,319 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class ReferenceProvider implements Base.BenchmarkProvider<Base.Objects> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile long dump;
+    public static volatile int incrementBy = 0;
+
+    public Base.Objects getNativeOffsets() {
+        return null;
+    }
+
+    static private final Base.Objects staticOffsets;
+    static {
+        class C1 {
+            static Object field;
+        }
+
+        class C2 {
+            static Object field;
+        }
+
+        class C3 {
+            static Object field;
+        }
+
+        class C4 {
+            static Object field;
+        }
+
+        class C5 {
+            static Object field;
+        }
+
+        try {
+            Field f1 = C1.class.getDeclaredField("field");
+            Field f2 = C2.class.getDeclaredField("field");
+            Field f3 = C3.class.getDeclaredField("field");
+            Field f4 = C4.class.getDeclaredField("field");
+            Field f5 = C5.class.getDeclaredField("field");
+
+            Object b1 = UNSAFE.staticFieldBase(f1);
+            Object b2 = UNSAFE.staticFieldBase(f2);
+            Object b3 = UNSAFE.staticFieldBase(f3);
+            Object b4 = UNSAFE.staticFieldBase(f4);
+            Object b5 = UNSAFE.staticFieldBase(f5);
+
+            C1.field = b2;
+            C2.field = b3;
+            C3.field = b4;
+            C4.field = b5;
+            C5.field = b1;
+
+            long offset = UNSAFE.staticFieldOffset(f1);
+
+            if (offset != UNSAFE.staticFieldOffset(f2)
+                || offset != UNSAFE.staticFieldOffset(f3)
+                || offset != UNSAFE.staticFieldOffset(f4)
+                || offset != UNSAFE.staticFieldOffset(f5)) {
+                throw new RuntimeException("Incorrect assumption that same shaped classes will have same static field offsets");
+            }
+
+            staticOffsets = new Base.Objects(b1, b2, b3, b4, b5, offset);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.Objects getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.Objects objectOffsets;
+    static {
+        class ObjectMember {
+            Object field;
+
+            public ObjectMember(Object f) {
+                field = f;
+            }
+        }
+
+        ObjectMember b1 = new ObjectMember(null);
+        ObjectMember b2 = new ObjectMember(b1);
+        ObjectMember b3 = new ObjectMember(b2);
+        ObjectMember b4 = new ObjectMember(b3);
+        ObjectMember b5 = new ObjectMember(b4);
+
+        b1.field = b5;
+
+        objectOffsets = new Base.Objects(
+            b1, b2, b3, b4, b5,
+            UNSAFE.objectFieldOffset(ObjectMember.class, "field")
+        );
+    }
+
+    public Base.Objects getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.Objects arrayOffsets;
+    static {
+        int offset = UNSAFE.arrayBaseOffset(Object[].class);
+
+        Object[] b1 = new Object[1];
+        Object[] b2 = {b1};
+        Object[] b3 = {b2};
+        Object[] b4 = {b3};
+        Object[] b5 = {b4};
+        b1[0] = b5;
+
+        arrayOffsets = new Base.Objects(b1, b2, b3, b4, b5, offset);
+    }
+
+    public Base.Objects getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.Objects objects) {
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            b1 = UNSAFE.getReference(b1, offset);
+            b2 = UNSAFE.getReference(b2, offset);
+            b3 = UNSAFE.getReference(b3, offset);
+            b4 = UNSAFE.getReference(b4, offset);
+            b5 = UNSAFE.getReference(b5, offset);
+        }
+
+        dump = System.identityHashCode(b1)
+             + System.identityHashCode(b2)
+             + System.identityHashCode(b3)
+             + System.identityHashCode(b4)
+             + System.identityHashCode(b5);
+
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.Objects objects) {
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            b1 = UNSAFE.getReferenceOpaque(b1, offset);
+            b2 = UNSAFE.getReferenceOpaque(b2, offset);
+            b3 = UNSAFE.getReferenceOpaque(b3, offset);
+            b4 = UNSAFE.getReferenceOpaque(b4, offset);
+            b5 = UNSAFE.getReferenceOpaque(b5, offset);
+        }
+
+        dump = System.identityHashCode(b1)
+             + System.identityHashCode(b2)
+             + System.identityHashCode(b3)
+             + System.identityHashCode(b4)
+             + System.identityHashCode(b5);
+
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.Objects objects) {
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            b1 = UNSAFE.getReferenceAcquire(b1, offset);
+            b2 = UNSAFE.getReferenceAcquire(b2, offset);
+            b3 = UNSAFE.getReferenceAcquire(b3, offset);
+            b4 = UNSAFE.getReferenceAcquire(b4, offset);
+            b5 = UNSAFE.getReferenceAcquire(b5, offset);
+        }
+
+        dump = System.identityHashCode(b1)
+             + System.identityHashCode(b2)
+             + System.identityHashCode(b3)
+             + System.identityHashCode(b4)
+             + System.identityHashCode(b5);
+
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.Objects objects) {
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            b1 = UNSAFE.getReferenceVolatile(b1, offset);
+            b2 = UNSAFE.getReferenceVolatile(b2, offset);
+            b3 = UNSAFE.getReferenceVolatile(b3, offset);
+            b4 = UNSAFE.getReferenceVolatile(b4, offset);
+            b5 = UNSAFE.getReferenceVolatile(b5, offset);
+        }
+
+        dump = System.identityHashCode(b1)
+             + System.identityHashCode(b2)
+             + System.identityHashCode(b3)
+             + System.identityHashCode(b4)
+             + System.identityHashCode(b5);
+
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.Objects objects) {
+        int inc = incrementBy;
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putReference(b1, offset, b5);
+            UNSAFE.putReference(b2, offset, b1);
+            UNSAFE.putReference(b3, offset, b2);
+            UNSAFE.putReference(b4, offset, b3);
+            UNSAFE.putReference(b5, offset, b4);
+            offset += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.Objects objects) {
+        int inc = incrementBy;
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putReferenceOpaque(b1, offset, b5);
+            UNSAFE.putReferenceOpaque(b2, offset, b1);
+            UNSAFE.putReferenceOpaque(b3, offset, b2);
+            UNSAFE.putReferenceOpaque(b4, offset, b3);
+            UNSAFE.putReferenceOpaque(b5, offset, b4);
+            offset += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.Objects objects) {
+        int inc = incrementBy;
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putReferenceRelease(b1, offset, b5);
+            UNSAFE.putReferenceRelease(b2, offset, b1);
+            UNSAFE.putReferenceRelease(b3, offset, b2);
+            UNSAFE.putReferenceRelease(b4, offset, b3);
+            UNSAFE.putReferenceRelease(b5, offset, b4);
+            offset += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.Objects objects) {
+        int inc = incrementBy;
+        long offset = objects.offset;
+        Object b1 = objects.base1;
+        Object b2 = objects.base2;
+        Object b3 = objects.base3;
+        Object b4 = objects.base4;
+        Object b5 = objects.base5;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putReferenceVolatile(b1, offset, b5);
+            UNSAFE.putReferenceVolatile(b2, offset, b1);
+            UNSAFE.putReferenceVolatile(b3, offset, b2);
+            UNSAFE.putReferenceVolatile(b4, offset, b3);
+            UNSAFE.putReferenceVolatile(b5, offset, b4);
+            offset += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/ShortProvider.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/ShortProvider.java
@@ -1,0 +1,308 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import jdk.internal.misc.Unsafe;
+import java.lang.Short;
+import java.lang.reflect.Field;
+import net.adoptopenjdk.bumblebench.unsafe.Base;
+
+public class ShortProvider implements Base.BenchmarkProvider<Base.RelativeOffsets> {
+    public static final Unsafe UNSAFE = Base.UNSAFE;
+    public static volatile int dump;
+    public static volatile int incrementBy = 0;
+
+    static private final Base.RelativeOffsets nativeOffsets;
+    static {
+        long baseOffset = UNSAFE.allocateMemory(5 * Short.BYTES);
+        short offset1 = (short) 0;
+        short offset2 = (short) Short.BYTES;
+        short offset3 = (short) 2 * Short.BYTES;
+        short offset4 = (short) 3 * Short.BYTES;
+        short offset5 = (short) 4 * Short.BYTES;
+
+        UNSAFE.putShort(null, baseOffset + offset1, offset2);
+        UNSAFE.putShort(null, baseOffset + offset2, offset3);
+        UNSAFE.putShort(null, baseOffset + offset3, offset4);
+        UNSAFE.putShort(null, baseOffset + offset4, offset5);
+        UNSAFE.putShort(null, baseOffset + offset5, offset1);
+
+        nativeOffsets = new Base.RelativeOffsets(null, baseOffset, offset1, offset2, offset3, offset4, offset5);
+    }
+
+    public Base.RelativeOffsets getNativeOffsets() {
+        return nativeOffsets;
+    }
+
+    static private final Base.RelativeOffsets staticOffsets;
+    static {
+        class StaticField {
+            public static short field1, field2, field3, field4, field5;
+        }
+
+        try {
+            Field f1 = StaticField.class.getDeclaredField("field1");
+            Field f2 = StaticField.class.getDeclaredField("field2");
+            Field f3 = StaticField.class.getDeclaredField("field3");
+            Field f4 = StaticField.class.getDeclaredField("field4");
+            Field f5 = StaticField.class.getDeclaredField("field5");
+
+            long baseOffset = UNSAFE.staticFieldOffset(f1);
+            short field1Offset = 0;
+            short field2Offset = (short) (UNSAFE.staticFieldOffset(f2) - baseOffset);
+            short field3Offset = (short) (UNSAFE.staticFieldOffset(f3) - baseOffset);
+            short field4Offset = (short) (UNSAFE.staticFieldOffset(f4) - baseOffset);
+            short field5Offset = (short) (UNSAFE.staticFieldOffset(f5) - baseOffset);
+
+            StaticField.field1 = field2Offset;
+            StaticField.field2 = field3Offset;
+            StaticField.field3 = field4Offset;
+            StaticField.field4 = field5Offset;
+            StaticField.field5 = field1Offset;
+
+            staticOffsets = new Base.RelativeOffsets(
+                UNSAFE.staticFieldBase(f1),
+                baseOffset,
+                field1Offset,
+                field2Offset,
+                field3Offset,
+                field4Offset,
+                field5Offset
+            );
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException("This should be unreachable", e);
+        }
+    }
+
+    public Base.RelativeOffsets getStaticOffsets() {
+        return staticOffsets;
+    }
+
+    static private final Base.RelativeOffsets objectOffsets;
+    static {
+        class ObjectMember {
+            public short field1, field2, field3, field4, field5;
+
+            public ObjectMember(short f1, short f2, short f3, short f4, short f5) {
+                field1 = f1;
+                field2 = f2;
+                field3 = f3;
+                field4 = f4;
+                field5 = f5;
+            }
+        }
+
+        long baseOffset = UNSAFE.objectFieldOffset(ObjectMember.class, "field1");
+        short field1Offset = 0;
+        short field2Offset = (short) (UNSAFE.objectFieldOffset(ObjectMember.class, "field2") - baseOffset);
+        short field3Offset = (short) (UNSAFE.objectFieldOffset(ObjectMember.class, "field3") - baseOffset);
+        short field4Offset = (short) (UNSAFE.objectFieldOffset(ObjectMember.class, "field4") - baseOffset);
+        short field5Offset = (short) (UNSAFE.objectFieldOffset(ObjectMember.class, "field5") - baseOffset);
+
+        objectOffsets = new Base.RelativeOffsets(
+            new ObjectMember(field2Offset, field3Offset, field4Offset, field5Offset, field1Offset),
+            baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset
+        );
+    }
+
+    public Base.RelativeOffsets getObjectOffsets() {
+        return objectOffsets;
+    }
+
+    static private final Base.RelativeOffsets arrayOffsets;
+    static {
+        int baseOffset = UNSAFE.arrayBaseOffset(short[].class);
+        int ascale = UNSAFE.arrayIndexScale(short[].class);
+        int shift = 31 - Integer.numberOfLeadingZeros(ascale);
+
+        short field1Offset = 0;
+        short field2Offset = (short) (1 << shift);
+        short field3Offset = (short) (2 << shift);
+        short field4Offset = (short) (3 << shift);
+        short field5Offset = (short) (4 << shift);
+
+        short[] arr = {field2Offset, field3Offset, field4Offset, field5Offset, field1Offset};
+
+        arrayOffsets = new Base.RelativeOffsets(arr, baseOffset, field1Offset, field2Offset, field3Offset, field4Offset, field5Offset);
+    }
+
+    public Base.RelativeOffsets getArrayOffsets() {
+        return arrayOffsets;
+    }
+
+    public long stressGet(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        short o1 = (short) offsets.field1Offset;
+        short o2 = (short) offsets.field2Offset;
+        short o3 = (short) offsets.field3Offset;
+        short o4 = (short) offsets.field4Offset;
+        short o5 = (short) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getShort(base, baseOffset + o1);
+            o2 = UNSAFE.getShort(base, baseOffset + o2);
+            o3 = UNSAFE.getShort(base, baseOffset + o3);
+            o4 = UNSAFE.getShort(base, baseOffset + o4);
+            o5 = UNSAFE.getShort(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        short o1 = (short) offsets.field1Offset;
+        short o2 = (short) offsets.field2Offset;
+        short o3 = (short) offsets.field3Offset;
+        short o4 = (short) offsets.field4Offset;
+        short o5 = (short) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getShortOpaque(base, baseOffset + o1);
+            o2 = UNSAFE.getShortOpaque(base, baseOffset + o2);
+            o3 = UNSAFE.getShortOpaque(base, baseOffset + o3);
+            o4 = UNSAFE.getShortOpaque(base, baseOffset + o4);
+            o5 = UNSAFE.getShortOpaque(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetAcquire(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        short o1 = (short) offsets.field1Offset;
+        short o2 = (short) offsets.field2Offset;
+        short o3 = (short) offsets.field3Offset;
+        short o4 = (short) offsets.field4Offset;
+        short o5 = (short) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getShortAcquire(base, baseOffset + o1);
+            o2 = UNSAFE.getShortAcquire(base, baseOffset + o2);
+            o3 = UNSAFE.getShortAcquire(base, baseOffset + o3);
+            o4 = UNSAFE.getShortAcquire(base, baseOffset + o4);
+            o5 = UNSAFE.getShortAcquire(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressGetVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        Object base = offsets.base;
+        long baseOffset = offsets.baseOffset;
+        short o1 = (short) offsets.field1Offset;
+        short o2 = (short) offsets.field2Offset;
+        short o3 = (short) offsets.field3Offset;
+        short o4 = (short) offsets.field4Offset;
+        short o5 = (short) offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            o1 = UNSAFE.getShortVolatile(base, baseOffset + o1);
+            o2 = UNSAFE.getShortVolatile(base, baseOffset + o2);
+            o3 = UNSAFE.getShortVolatile(base, baseOffset + o3);
+            o4 = UNSAFE.getShortVolatile(base, baseOffset + o4);
+            o5 = UNSAFE.getShortVolatile(base, baseOffset + o5);
+        }
+
+        dump = o1 + o2 + o3 + o4 + o5;
+        return numIterations;
+    }
+
+    public long stressPut(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putShort(base, o1, (short) i); o1 += inc;
+            UNSAFE.putShort(base, o2, (short) i); o2 += inc;
+            UNSAFE.putShort(base, o3, (short) i); o3 += inc;
+            UNSAFE.putShort(base, o4, (short) i); o4 += inc;
+            UNSAFE.putShort(base, o5, (short) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutOpaque(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putShortOpaque(base, o1, (short) i); o1 += inc;
+            UNSAFE.putShortOpaque(base, o2, (short) i); o2 += inc;
+            UNSAFE.putShortOpaque(base, o3, (short) i); o3 += inc;
+            UNSAFE.putShortOpaque(base, o4, (short) i); o4 += inc;
+            UNSAFE.putShortOpaque(base, o5, (short) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutRelease(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putShortRelease(base, o1, (short) i); o1 += inc;
+            UNSAFE.putShortRelease(base, o2, (short) i); o2 += inc;
+            UNSAFE.putShortRelease(base, o3, (short) i); o3 += inc;
+            UNSAFE.putShortRelease(base, o4, (short) i); o4 += inc;
+            UNSAFE.putShortRelease(base, o5, (short) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+
+    public long stressPutVolatile(long numIterations, Base.RelativeOffsets offsets) {
+        int inc = incrementBy;
+        Object base = offsets.base;
+        long o1 = offsets.baseOffset + offsets.field1Offset;
+        long o2 = offsets.baseOffset + offsets.field2Offset;
+        long o3 = offsets.baseOffset + offsets.field3Offset;
+        long o4 = offsets.baseOffset + offsets.field4Offset;
+        long o5 = offsets.baseOffset + offsets.field5Offset;
+
+        for (long i = 0; i < numIterations; i++) {
+            UNSAFE.putShortVolatile(base, o1, (short) i); o1 += inc;
+            UNSAFE.putShortVolatile(base, o2, (short) i); o2 += inc;
+            UNSAFE.putShortVolatile(base, o3, (short) i); o3 += inc;
+            UNSAFE.putShortVolatile(base, o4, (short) i); o4 += inc;
+            UNSAFE.putShortVolatile(base, o5, (short) i); o5 += inc;
+        }
+
+        return numIterations;
+    }
+}

--- a/net/adoptopenjdk/bumblebench/unsafe/UnsafeBench.java
+++ b/net/adoptopenjdk/bumblebench/unsafe/UnsafeBench.java
@@ -1,0 +1,1902 @@
+/*******************************************************************************
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+package net.adoptopenjdk.bumblebench.unsafe;
+
+import net.adoptopenjdk.bumblebench.unsafe.*;
+import net.adoptopenjdk.bumblebench.core.MicroBench;
+
+public class UnsafeBench {
+    public static class Get {
+        public static class Byte {
+            static Base.BenchmarkProvider provider = new ByteProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Char {
+            static Base.BenchmarkProvider provider = new CharProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Short {
+            static Base.BenchmarkProvider provider = new ShortProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Int {
+            static Base.BenchmarkProvider provider = new IntProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Boolean {
+            static Base.BenchmarkProvider provider = new BooleanProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Double {
+            static Base.BenchmarkProvider provider = new DoubleProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Float {
+            static Base.BenchmarkProvider provider = new FloatProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Long {
+            static Base.BenchmarkProvider provider = new LongProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Reference {
+            static Base.BenchmarkProvider provider = new ReferenceProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGet(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetAcquire(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressGetVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+        }
+    }
+
+    public static class Put {
+        public static class Byte {
+            static Base.BenchmarkProvider provider = new ByteProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Char {
+            static Base.BenchmarkProvider provider = new CharProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Short {
+            static Base.BenchmarkProvider provider = new ShortProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Int {
+            static Base.BenchmarkProvider provider = new IntProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Boolean {
+            static Base.BenchmarkProvider provider = new BooleanProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Double {
+            static Base.BenchmarkProvider provider = new DoubleProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Float {
+            static Base.BenchmarkProvider provider = new FloatProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Long {
+            static Base.BenchmarkProvider provider = new LongProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+
+                public static class Native extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getNativeOffsets());
+                    }
+                }
+            }
+        }
+
+        public static class Reference {
+            static Base.BenchmarkProvider provider = new ReferenceProvider();
+            public static class Plain {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPut(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+
+            public static class Opaque {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutOpaque(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+
+            public static class Acquire {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutRelease(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+
+            public static class Volatile {
+                public static class ObjectMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getObjectOffsets());
+                    }
+                }
+
+                public static class StaticMember extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getStaticOffsets());
+                    }
+                }
+
+                public static class Array extends MicroBench {
+                    protected long doBatch(long numIterations) {
+                       return provider.stressPutVolatile(numIterations, provider.getArrayOffsets());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds benchmarks for all the Unsafe get and set methods of the form `Unsafe.[Operation][Data Type][Memory Semantics]` accessing values in object members, static class fields, arrays, and native memory. The benchmark names have the form

`UnsafeBench.[Operation].[Data Type].[Memory Semantics].[Location Type]`

where:

Operation is one of
  - Put
  - Get

Data Type is one of
  - Boolean
  - Byte
  - Char
  - Double
  - Float
  - Int
  - Long
  - Reference
  - Short

Memory Semantics is one of
  - Acquire
  - Release
  - Opaque
  - Volatile
  - Plain

Location Type is one of
  - ObjectMember
  - StaticField
  - Array
  - NativeAddress

Notes:
  - There are no Reference NativeAddress benchmarks
  - There are only Get Acquire benchmarks
  - There are only Put Release benchamrks
  - These benchmarks require adding the flag `"--add-exports java.base/jdk.internal.misc=ALL-UNNAMED"`